### PR TITLE
#3: Allow to auto detect external service dependencies and spin up se…

### DIFF
--- a/libs/helper-vars.mk
+++ b/libs/helper-vars.mk
@@ -96,7 +96,7 @@ define get_dcutil_project_working_dir
 	fi
 endef
 
-# Get this project's docker compose file or return error
+# Get this project's docker compose file
 define get_dcutil_project_docker_compose_files
 	pld=$$dcutil_libs; \
 	dcfs_dir="$${pld}/docker-compose"; \

--- a/libs/vars.mk
+++ b/libs/vars.mk
@@ -8,6 +8,6 @@ cnt_user = root
 helper_ts = show_commands commands targets show_projects projects rm_vars
 validation_ts = check_not_root isset_p isset_valid_p is_code_project_exist isset_env isset_valid_cf
 build_ts = build
-dc_ts = dc_start dc_stop dc_ps dc_up dc_up_detailed dc_down dc_login dc_cmdn dc_workstation dc_images
+dc_ts = dc_start dc_stop dc_ps dc_up dc_up_dependencies dc_up_detailed dc_down dc_login dc_cmdn dc_workstation dc_images
 all_ts = $(helper_ts) $(validation_ts) $(build_ts) $(dc_ts)
 , = ,


### PR DESCRIPTION
Currently, when user issues a dc_up on a project, it will only trigger that particular project compose files to execute. However, if for instance a docker compose file adds external_links and dependencies to services outside of that compose file, user will have to manually have the services up first. Currently docker-compose or docker itself does not have any support for external dependencies. This feature has to be setup as a helper to first detect if there is any dependencies, then service up those dependencies, before executing the current project up.

**Acceptance criteria:**

- Dependency services must be setup in separate docker-compose file, and must be added to .env PROJECTS var
- User can set project external service dependencies via a variable similar to PROJECT__SERVICE_DEPENDENCIES.
- Allow PROJECT__SERVICE_DEPENDENCIES to accept value consisting dependency project name, and optional service(s). If no service(s) have been defined, then, all services will be spun up.
-if a dependency has dependencies, it should be set on PROJECT__SERVICE_DEPENDENCIES as above.